### PR TITLE
Fix: fixed scripts for herokus deployment

### DIFF
--- a/data/migrations/20200312193602_users.ts
+++ b/data/migrations/20200312193602_users.ts
@@ -7,14 +7,8 @@ export async function up(knex: Knex): Promise<any> {
       .string("username", 25)
       .notNullable()
       .unique();
-    table
-      .string("first_name", 50)
-      .notNullable()
-      .unique();
-    table
-      .string("last_name", 50)
-      .notNullable()
-      .unique();
+    table.string("first_name", 50).notNullable();
+    table.string("last_name", 50).notNullable();
     table.string("company", 50).unique();
     table
       .string("password", 255)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "nusite-be",
   "version": "1.0.0",
-  "description": "🚫 Note: All lines that start with 🚫 are instructions and should be deleted before this is posted to your portfolio. This is intended to be a guideline. Feel free to add your own flare to it.",
+  "description": "A site needs users. To support users, we need to create a basic scaffold for our site that gets them in the door and allows them to sign up for the service.",
   "main": "index.js",
   "scripts": {
-    "prestart": "tsc -p .",
-    "start": "node 'dist/index.js'",
+    "start": "node dist/index.js",
     "server": "nodemon index.ts",
-    "build": "tsc -p .",
+    "build": "npx tsc -p .",
     "format": "prettier \"**/*.{ts,tsx}\" --write",
     "migrate": "knex migrate:latest",
     "rollback": "knex migrate:rollback",


### PR DESCRIPTION
# Description
Fixed scripts for heroku deployment

Fixes # (issue)
Heroku couldn't find tsc for the prestart script, tested by using npx before the build command and heroku still would not work. Removed prestart script and deployment worked perfectly.

## Type of change
Removed prestart script and deployment worked perfectly.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
