### PR TITLE
Fix/linkedin error handling

### DIFF
--- a/authconfig/linkedin.ts
+++ b/authconfig/linkedin.ts
@@ -11,12 +11,15 @@ passport.use(
       callbackURL: process.env.LINKEDIN_CALLBACK_URL,
       scope: ["r_emailaddress", "r_liteprofile"],
     },
-    (_accessToken: string, _refreshToken: string, profile: any, done: any) => {
+    (
+      _accessToken: string,
+      _refreshToken: string,
+      profile: ProfileValues,
+      done: any
+    ) => {
       // asynchronous verification, for effect...
       process.nextTick(async function() {
-        // To keep the example simple, the user's LinkedIn profile is returned to
-        // represent the logged-in user. In a typical application, you would want
-        // to associate the LinkedIn account with a user record in your database,
+        // associate the LinkedIn account with a user record in your database,
         // and return that user instead.
 
         // Checks for the user by the linkedin profile id
@@ -49,7 +52,7 @@ passport.use(
             auth_id: profile.id,
           };
 
-          const [{ password, ...user }]: any = await User.add(newUser);
+          const [{ password, ...user }] = await User.add(newUser);
 
           return done(null, user);
         } else {
@@ -59,3 +62,14 @@ passport.use(
     }
   )
 );
+
+interface ProfileValues {
+  displayName: string;
+  name: {
+    givenName: string;
+    familyName: string;
+  };
+  emails: [{ value: string }];
+  provider: string;
+  id: string;
+}

--- a/authconfig/linkedin.ts
+++ b/authconfig/linkedin.ts
@@ -30,18 +30,15 @@ passport.use(
 
         // Return the user
         if (checkUser) {
-          let updateProvider = await User.update(checkUser.id, {
-            provider: profile.provider,
-            auth_id: profile.id,
-          });
-          return done(null, updateProvider);
+          return done(null, checkUser);
         }
 
-        // if no user is found attempt to create a new user
+        // if no user is found by auth_id or email attempt to create a new user
         if (!findUser && !checkUser) {
           const pw = await hash(profile.displayName, 12);
 
           // if no email for the user exists, create a new db entry
+          // with fields from the users profile
           const newUser = {
             username: profile.displayName,
             first_name: profile.name.givenName,

--- a/authconfig/linkedin.ts
+++ b/authconfig/linkedin.ts
@@ -18,19 +18,26 @@ passport.use(
         // represent the logged-in user. In a typical application, you would want
         // to associate the LinkedIn account with a user record in your database,
         // and return that user instead.
+
+        // Checks for the user by the linkedin profile id
         const findUser = await User.findBy({ auth_id: profile.id });
 
+        // if no user is found attempt to create a new user
         if (!findUser) {
           const pw = await hash(profile.displayName, 12);
 
+          // IF a user exists with the same email, return that user
+          // means user signed up with different service
           const checkUser = await User.findBy({
             email: profile.emails[0].value,
           });
 
+          // Return the user
           if (checkUser) {
             return done(null, checkUser);
           }
 
+          // if no email for the user exists, create a new db entry
           const newUser = {
             username: profile.displayName,
             first_name: profile.name.givenName,
@@ -45,6 +52,8 @@ passport.use(
 
           return done(null, user);
         } else {
+          // Potential fix for previous users that have
+          // already signed up on master without these fields
           if (findUser.provider !== profile.provider) {
             await User.update(findUser.id, {
               provider: profile.provider,

--- a/data/migrations/20200518213830_user_provider.ts
+++ b/data/migrations/20200518213830_user_provider.ts
@@ -1,0 +1,13 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<any> {
+  await knex.schema.table("users", tbl => {
+    tbl.string("provider", 50);
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  await knex.schema.table("users", tbl => {
+    tbl.dropColumn("provider");
+  });
+}

--- a/routes/linkedin.ts
+++ b/routes/linkedin.ts
@@ -2,11 +2,17 @@ const linkedinRouter = require("express").Router();
 import passport from "passport";
 import generateToken from "../token/generateToken";
 
-linkedinRouter.get("/api/auth/linkedin", passport.authenticate("linkedin"));
+linkedinRouter.get(
+  "/api/auth/linkedin",
+  passport.authenticate("linkedin", {
+    failureRedirect: `${process.env.REDIRECT_URL}/login`,
+  })
+);
 
 linkedinRouter.get(
   "/api/auth/linkedin/callback",
   passport.authenticate("linkedin", {
+    failureRedirect: `${process.env.REDIRECT_URL}/login`,
     passReqToCallback: true,
     session: false,
   }),

--- a/routes/linkedin.ts
+++ b/routes/linkedin.ts
@@ -16,7 +16,7 @@ linkedinRouter.get(
     passReqToCallback: true,
     session: false,
   }),
-  (req: { user: { id: number; username: string }; headers: any }, res: any) => {
+  (req: { user: { id: number; username: string } }, res: any) => {
     let user = {
       id: req.user.id,
       username: req.user.username,

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,7 +20,7 @@ const typeDefs = gql`
     dev_experience: String
     dev_education: String
     projects: [Project]
-    googleId: String
+    provider: String
   }
 
   type Project {


### PR DESCRIPTION
# Description
Potential implementation for fixing login issues between oauth providers.

Mainly creating to discuss for the time being.
Passport documentation is terrible, I can't get the failure redirect to work at all.

implementation searches for user by the auth_id now.
If no user is found checks the user email, if user with that email exists, returns that user

This is just a quick implementation and still needs work

Fixes # (issue)
Issues with signing up with dual oauth providers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Manual testing on local db after reseeding

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
